### PR TITLE
Fix prayer reminder window robustness

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import {
   setConfig,
 } from "./services/db";
 import type { PrayerCacheRow } from "./services/db";
-import { fetchPrayerTimes, getDueReminders, getNowInTimezone, isReminderTime } from "./services/prayer";
+import { fetchPrayerTimes, getDueReminders, getNowInTimezone, isReminderDue } from "./services/prayer";
 import { formatReminder, formatKahfReminder } from "./services/format";
 import { DEFAULT_TZ, DEFAULT_CITY, DEFAULT_COUNTRY } from "./config";
 
@@ -128,7 +128,7 @@ export async function handleScheduled(db: D1Database, botToken: string): Promise
   if (dayOfWeek === "Friday") {
     const kahfReminderLast = await getConfig(db, "kahf_reminder_last");
     if (kahfReminderLast !== today) {
-      if (isReminderTime(nowHHMM, cache.fajr)) {
+      if (isReminderDue(nowHHMM, cache.fajr)) {
         const kahfStats = await getKahfStats(db);
         const kahfMsg = formatKahfReminder({
           lastDate: kahfStats.lastDate ?? undefined,

--- a/src/services/prayer.ts
+++ b/src/services/prayer.ts
@@ -71,9 +71,9 @@ function timeToMinutes(hhmm: string): number {
   return h * 60 + m;
 }
 
-export function isReminderTime(nowHHMM: string, prayerHHMM: string): boolean {
+export function isReminderDue(nowHHMM: string, prayerHHMM: string): boolean {
   const diff = timeToMinutes(nowHHMM) - timeToMinutes(prayerHHMM);
-  return diff >= 10 && diff <= 14;
+  return diff >= 0;
 }
 
 const PRAYER_NAMES: readonly PrayerName[] = ["fajr", "dhuhr", "asr", "maghrib", "isha"];
@@ -82,7 +82,7 @@ export function getDueReminders(cache: PrayerCacheRow, nowHHMM: string): PrayerN
   return PRAYER_NAMES.filter((name) => {
     const prayerTime = cache[name];
     const sentFlag = cache[`${name}_sent` as keyof PrayerCacheRow] as number;
-    return sentFlag === 0 && isReminderTime(nowHHMM, prayerTime);
+    return sentFlag === 0 && isReminderDue(nowHHMM, prayerTime);
   });
 }
 

--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -25,7 +25,7 @@ vi.mock("../src/services/prayer", async (importOriginal) => {
     fetchPrayerTimes: vi.fn(),
     getDueReminders: vi.fn(),
     getNowInTimezone: vi.fn(),
-    isReminderTime: vi.fn(),
+    isReminderDue: vi.fn(),
   };
 });
 
@@ -48,7 +48,7 @@ import {
   getKahfStats,
   setConfig,
 } from "../src/services/db";
-import { fetchPrayerTimes, getDueReminders, getNowInTimezone, isReminderTime } from "../src/services/prayer";
+import { fetchPrayerTimes, getDueReminders, getNowInTimezone, isReminderDue } from "../src/services/prayer";
 import { formatReminder, formatKahfReminder } from "../src/services/format";
 
 describe("handleScheduled", () => {
@@ -292,7 +292,7 @@ describe("handleScheduled", () => {
       });
       vi.mocked(getNowInTimezone).mockReturnValue("05:42");
       vi.mocked(getDueReminders).mockReturnValue([]);
-      vi.mocked(isReminderTime).mockReturnValue(true);
+      vi.mocked(isReminderDue).mockReturnValue(true);
       vi.mocked(getKahfStats).mockResolvedValue({ lastDuration: null, lastDate: null });
       vi.mocked(formatKahfReminder).mockReturnValue("Rappel Al-Kahf");
 
@@ -410,7 +410,7 @@ describe("handleScheduled", () => {
       });
       vi.mocked(getNowInTimezone).mockReturnValue("05:42");
       vi.mocked(getDueReminders).mockReturnValue([]);
-      vi.mocked(isReminderTime).mockReturnValue(true);
+      vi.mocked(isReminderDue).mockReturnValue(true);
       vi.mocked(getKahfStats).mockResolvedValue({ lastDuration: 1500, lastDate: "2026-03-07" });
       vi.mocked(formatKahfReminder).mockReturnValue("Rappel Al-Kahf avec stats");
 

--- a/tests/prayer.test.ts
+++ b/tests/prayer.test.ts
@@ -4,7 +4,7 @@ import {
   parsePrayerResponse,
   buildAladhanUrl,
   fetchPrayerTimes,
-  isReminderTime,
+  isReminderDue,
   getDueReminders,
   getNowInTimezone,
 } from "../src/services/prayer";
@@ -125,24 +125,21 @@ describe("fetchPrayerTimes", () => {
   });
 });
 
-describe("isReminderTime", () => {
-  it("true a prayer+10min (borne inf)", () => {
-    expect(isReminderTime("12:10", "12:00")).toBe(true);
+describe("isReminderDue", () => {
+  it("true a l'heure exacte de la priere", () => {
+    expect(isReminderDue("12:00", "12:00")).toBe(true);
   });
-  it("true a prayer+14min (borne sup)", () => {
-    expect(isReminderTime("12:14", "12:00")).toBe(true);
+  it("true 1min apres la priere", () => {
+    expect(isReminderDue("12:01", "12:00")).toBe(true);
   });
-  it("false a prayer+9min (trop tot)", () => {
-    expect(isReminderTime("12:09", "12:00")).toBe(false);
+  it("true 30min apres la priere (tick retarde)", () => {
+    expect(isReminderDue("12:30", "12:00")).toBe(true);
   });
-  it("false a prayer+15min (trop tard)", () => {
-    expect(isReminderTime("12:15", "12:00")).toBe(false);
+  it("false 1min avant la priere", () => {
+    expect(isReminderDue("11:59", "12:00")).toBe(false);
   });
-  it("true a prayer+12min (milieu)", () => {
-    expect(isReminderTime("12:12", "12:00")).toBe(true);
-  });
-  it("false sur passage minuit (cas impossible en pratique)", () => {
-    expect(isReminderTime("00:05", "23:55")).toBe(false);
+  it("false sur passage minuit (diff negatif)", () => {
+    expect(isReminderDue("00:05", "23:55")).toBe(false);
   });
 });
 
@@ -155,16 +152,28 @@ const makeCache = (overrides: Partial<PrayerCacheRow> = {}): PrayerCacheRow => (
 });
 
 describe("getDueReminders", () => {
-  it("retourne la priere dans la fenetre", () => {
-    expect(getDueReminders(makeCache(), "12:12")).toEqual(["dhuhr"]);
+  it("retourne toutes les prieres passees non envoyees", () => {
+    expect(getDueReminders(makeCache(), "12:00")).toEqual(["fajr", "dhuhr"]);
+  });
+
+  it("retourne la priere meme avec un tick tres retarde", () => {
+    expect(getDueReminders(makeCache({ fajr_sent: 1 }), "12:30")).toEqual(["dhuhr"]);
   });
 
   it("retourne [] si deja envoyee", () => {
-    expect(getDueReminders(makeCache({ dhuhr_sent: 1 }), "12:12")).toEqual([]);
+    expect(getDueReminders(makeCache({ fajr_sent: 1, dhuhr_sent: 1 }), "12:30")).toEqual([]);
   });
 
-  it("retourne [] si aucune priere dans la fenetre", () => {
-    expect(getDueReminders(makeCache(), "14:00")).toEqual([]);
+  it("retourne [] si aucune priere n'est encore passee", () => {
+    expect(getDueReminders(makeCache(), "05:29")).toEqual([]);
+  });
+
+  it("retourne plusieurs prieres si tick retarde couvre plusieurs", () => {
+    expect(getDueReminders(makeCache(), "20:00")).toEqual(["fajr", "dhuhr", "asr", "maghrib", "isha"]);
+  });
+
+  it("exclut les prieres deja envoyees parmi plusieurs dues", () => {
+    expect(getDueReminders(makeCache({ fajr_sent: 1, dhuhr_sent: 1 }), "20:00")).toEqual(["asr", "maghrib", "isha"]);
   });
 });
 


### PR DESCRIPTION
## Summary

- Simplified reminder logic from a narrow 4-minute window (10-14 min after prayer) to triggering immediately when prayer time is reached
- The existing `_sent` flag prevents duplicate reminders
- Fixes issue #11: handles Cloudflare Workers tick delays without missing reminders

## What Changed

- Renamed `isReminderTime` to `isReminderDue` with simplified logic: `diff >= 0` instead of `diff >= 10 && diff <= 14`
- Updated all tests to reflect the new behavior, including cases for delayed ticks

## Testing

All 291 tests pass. New test cases cover:
- Reminders triggered at exact prayer time
- Reminders with delayed ticks (30+ minutes)
- Exclusion of already-sent reminders via flag
- Multiple simultaneous due reminders

🤖 Generated with Claude Code