### PR TITLE
Add /undo command to delete last session with confirmation details

### DIFF
--- a/src/handlers/manage.ts
+++ b/src/handlers/manage.ts
@@ -73,15 +73,12 @@ export async function confirmDeleteCallback(
   }
 
   const id = parseInt(data.split(":")[1], 10);
-  const session = await getSessionById(ctx.db, id);
-  const deleted = await deleteSessionById(ctx.db, id);
+  const session = await deleteSessionById(ctx.db, id);
 
-  if (deleted && session) {
+  if (session) {
     const range = formatRange(session.surahStart, session.ayahStart, session.surahEnd, session.ayahEnd);
     const duration = formatDuration(session.durationSeconds);
     await ctx.editMessageText(`Session #${id} supprimee.\n${range} -- ${session.ayahCount} versets en ${duration}`);
-  } else if (deleted) {
-    await ctx.editMessageText(`Session #${id} supprimee.`);
   } else {
     await ctx.editMessageText(`Session #${id} introuvable.`);
   }

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -228,12 +228,12 @@ export async function getLastSession(
 export async function deleteSessionById(
   db: D1Database,
   id: number,
-): Promise<boolean> {
-  const result = await db
-    .prepare("DELETE FROM sessions WHERE id = ?")
+): Promise<Session | null> {
+  const row = await db
+    .prepare("DELETE FROM sessions WHERE id = ? RETURNING *")
     .bind(id)
-    .run();
-  return result.meta.changes > 0;
+    .first<SessionRow>();
+  return row ? mapRow(row) : null;
 }
 
 export async function insertBatch(

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -210,18 +210,19 @@ describe("getLastSession", () => {
 // --- deleteSessionById ---
 
 describe("deleteSessionById", () => {
-  it("returns true when a session is deleted", async () => {
+  it("returns the deleted session", async () => {
     const session = unwrap(await insertSession(db, makeSession()));
     const deleted = await deleteSessionById(db, session.id);
-    expect(deleted).toBe(true);
+    expect(deleted).not.toBeNull();
+    expect(deleted!.id).toBe(session.id);
 
     const found = await getSessionById(db, session.id);
     expect(found).toBeNull();
   });
 
-  it("returns false for a non-existent ID", async () => {
+  it("returns null for a non-existent ID", async () => {
     const deleted = await deleteSessionById(db, 999);
-    expect(deleted).toBe(false);
+    expect(deleted).toBeNull();
   });
 });
 

--- a/tests/handlers/manage.test.ts
+++ b/tests/handlers/manage.test.ts
@@ -38,11 +38,10 @@ function createCommandContext(match = "", firstResult: unknown = null): CustomCo
   } as unknown as CustomContext;
 }
 
-function createCallbackContext(data: string, changes = 1, sessionRow: unknown = null): CustomContext {
-  const runFn = vi.fn().mockResolvedValue({ meta: { changes } });
+function createCallbackContext(data: string, sessionRow: unknown = null): CustomContext {
   const firstFn = vi.fn().mockResolvedValue(sessionRow);
-  const bindFn = vi.fn().mockReturnValue({ run: runFn, first: firstFn, all: vi.fn() });
-  const prepareFn = vi.fn().mockReturnValue({ bind: bindFn, run: runFn, first: firstFn, all: vi.fn() });
+  const bindFn = vi.fn().mockReturnValue({ run: vi.fn(), first: firstFn, all: vi.fn() });
+  const prepareFn = vi.fn().mockReturnValue({ bind: bindFn, run: vi.fn(), first: firstFn, all: vi.fn() });
 
   return {
     callbackQuery: { data },
@@ -119,7 +118,7 @@ describe("deleteHandler", () => {
 
 describe("confirmDeleteCallback", () => {
   it("supprime la session et affiche les details", async () => {
-    const ctx = createCallbackContext("delete_confirm:42", 1, MOCK_SESSION_ROW);
+    const ctx = createCallbackContext("delete_confirm:42", MOCK_SESSION_ROW);
     await confirmDeleteCallback(ctx);
     const msg = (ctx.editMessageText as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(msg).toContain("Session #42 supprimee.");
@@ -129,15 +128,8 @@ describe("confirmDeleteCallback", () => {
     expect(ctx.answerCallbackQuery).toHaveBeenCalled();
   });
 
-  it("supprime sans details si session deja absente de la DB", async () => {
-    const ctx = createCallbackContext("delete_confirm:42", 1, null);
-    await confirmDeleteCallback(ctx);
-    expect(ctx.editMessageText).toHaveBeenCalledWith("Session #42 supprimee.");
-    expect(ctx.answerCallbackQuery).toHaveBeenCalled();
-  });
-
   it("affiche introuvable si deja supprimee", async () => {
-    const ctx = createCallbackContext("delete_confirm:42", 0);
+    const ctx = createCallbackContext("delete_confirm:42", null);
     await confirmDeleteCallback(ctx);
     expect(ctx.editMessageText).toHaveBeenCalledWith("Session #42 introuvable.");
   });


### PR DESCRIPTION
Allows users to cancel their most recent reading session via /undo.
The confirmation message includes session details: date range, verse count,
and reading duration for transparency.

Tests cover both successful deletion with details and fallback when session
is already absent from the database.