### PR TITLE
Fix CI deploy by injecting D1 database ID from secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         # Requires BOT_TOKEN and ALLOWED_USER_ID to be set as Cloudflare secrets
         # (via wrangler secret put) before first deploy
         run: |
+          sed -i 's/<YOUR_D1_DATABASE_ID>/${{ secrets.D1_DATABASE_ID }}/' wrangler.toml
           DEPLOY_OUTPUT=$(npx wrangler deploy 2>&1)
           echo "$DEPLOY_OUTPUT"
           WORKER_URL=$(echo "$DEPLOY_OUTPUT" | grep -oE 'https://[^ ]+workers\.dev')

--- a/README.md
+++ b/README.md
@@ -112,6 +112,19 @@ This registers the command menu in Telegram. Run it once after deploying, or aga
 
 The cron trigger (`*/5 * * * *`) handles prayer time reminders automatically.
 
+### CI/CD
+
+The GitHub Actions workflow (`.github/workflows/ci.yml`) runs tests on every PR and deploys to Cloudflare on push to `main`.
+
+Required GitHub repository secrets:
+
+| Secret | Description |
+|---|---|
+| `CLOUDFLARE_API_TOKEN` | Cloudflare API token with Workers permissions |
+| `CLOUDFLARE_ACCOUNT_ID` | Your Cloudflare account ID |
+| `D1_DATABASE_ID` | The D1 database UUID (from `wrangler d1 create`) |
+| `BOT_TOKEN` | Telegram bot token (used to register commands post-deploy) |
+
 ## Configuration
 
 Use `/config` to set your location for prayer time reminders:


### PR DESCRIPTION
## Description

The open source release replaced the real D1 `database_id` in `wrangler.toml` with a placeholder, which broke the CI deploy step. This PR injects the database ID from a `D1_DATABASE_ID` GitHub secret via `sed` before running `wrangler deploy`, and documents all required CI secrets in the README.

**Action required:** Add the `D1_DATABASE_ID` secret to the GitHub repository settings.

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Follows existing code patterns
- [x] No secrets or credentials committed