### PR TITLE
Fix pace calculation to use strict 14-day average

### DIFF
--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -629,12 +629,6 @@ export async function calculateStreak(
 
 // --- Pace ---
 
-function diffDays(from: string, to: string): number {
-  const a = new Date(`${from}T00:00:00Z`);
-  const b = new Date(`${to}T00:00:00Z`);
-  return Math.round((b.getTime() - a.getTime()) / (1000 * 60 * 60 * 24));
-}
-
 export async function getRecentPace(
   db: D1Database,
   tz: string,
@@ -644,8 +638,7 @@ export async function getRecentPace(
   const startDate = addDays(today, -(days - 1));
   const row = await db
     .prepare(
-      `SELECT COALESCE(SUM(${ADJ_PAGE_COUNT_SQL}), 0) AS total_pages,
-              MIN(started_at) AS first_started_at
+      `SELECT COALESCE(SUM(${ADJ_PAGE_COUNT_SQL}), 0) AS total_pages
        FROM sessions
        WHERE type = 'normal'
          AND page_start IS NOT NULL
@@ -653,17 +646,12 @@ export async function getRecentPace(
          AND started_at >= ?`
     )
     .bind(`${startDate} 00:00:00`)
-    .first<{ total_pages: number; first_started_at: string | null }>();
+    .first<{ total_pages: number }>();
   if (!row || row.total_pages === 0) {
     return 0;
   }
 
-  const firstDate = row.first_started_at?.slice(0, 10);
-  if (!firstDate) {
-    return 0;
-  }
-  const effectiveDays = diffDays(firstDate, today) + 1;
-  return row.total_pages / Math.min(days, effectiveDays);
+  return row.total_pages / days;
 }
 
 // --- Speed functions ---

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1149,13 +1149,13 @@ describe("helper functions", () => {
 // --- getRecentPace ---
 
 describe("getRecentPace", () => {
-  it("calculates pace using effective days, not full window", async () => {
+  it("calculates pace using full 14-day window", async () => {
     const today = getTodayInTimezone("America/Cancun");
     const d1 = addDays(today, -1);
     const d2 = addDays(today, -3);
 
     // 3 pages on d1, 5 pages on d2 = 8 pages total
-    // Effective days = from d2 to today = 4 days
+    // Always divided by 14 days
     unwrap(
       await insertSession(
         db,
@@ -1180,7 +1180,7 @@ describe("getRecentPace", () => {
     );
 
     const pace = await getRecentPace(db, "America/Cancun");
-    expect(pace).toBeCloseTo(8 / 4);
+    expect(pace).toBeCloseTo(8 / 14);
   });
 
   it("uses full window when history spans all 14 days", async () => {


### PR DESCRIPTION
## Description

`getRecentPace()` divided pages by `effectiveDays` (days since first session in window), which inflated the pace when reading only a few days out of 14. Now always divides by the full 14-day window to reflect the real sustained pace.

Removes the unused `diffDays` helper and simplifies the SQL query (no longer needs `MIN(started_at)`).

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Follows existing code patterns
- [x] No secrets or credentials committed