### PR TITLE
Fix Al-Kahf first page weight for speed calculation

### DIFF
--- a/src/data/pages.ts
+++ b/src/data/pages.ts
@@ -619,8 +619,8 @@ export const KAHF_PAGE_START = 293;
 export const KAHF_PAGE_END = 304;
 export const KAHF_TOTAL_PAGES = 12;
 
-/** Fraction of page 293 that is Al-Kahf content (6 lines / 15 lines) */
-export const KAHF_FIRST_PAGE_WEIGHT = 0.4;
+/** Fraction of page 293 that is Al-Kahf verse content (4 lines / 15 lines, excluding surah title and basmala) */
+export const KAHF_FIRST_PAGE_WEIGHT = 4 / 15;
 
 /** Effective page count, adjusting for partial Kahf first page */
 export function effectivePageCount(

--- a/src/handlers/kahf.ts
+++ b/src/handlers/kahf.ts
@@ -1,6 +1,7 @@
 // src/handlers/kahf.ts
 import type { CustomContext } from "../bot";
 import {
+  effectivePageCount,
   getNextKahfPage,
   getPageRange,
   KAHF_PAGE_END,
@@ -89,6 +90,7 @@ export async function kahfHandler(ctx: CustomContext): Promise<void> {
     durationSeconds;
 
   const isComplete = weekPagesRead >= KAHF_TOTAL_PAGES;
+  const sessionPages = effectivePageCount(pageStart, pageEnd, "kahf");
 
   if (isComplete) {
     const lastWeekResult = await getLastWeekKahfTotal(ctx.db, tz);
@@ -108,7 +110,7 @@ export async function kahfHandler(ctx: CustomContext): Promise<void> {
           isComplete: true,
           lastWeekTotalSeconds:
             lastWeekTotalSeconds > 0 ? lastWeekTotalSeconds : undefined,
-          sessionPages: count,
+          sessionPages,
         },
         t
       )
@@ -123,7 +125,7 @@ export async function kahfHandler(ctx: CustomContext): Promise<void> {
           weekPagesRead,
           weekTotalSeconds,
           isComplete: false,
-          sessionPages: count,
+          sessionPages,
         },
         t
       )

--- a/src/handlers/timer.ts
+++ b/src/handlers/timer.ts
@@ -2,6 +2,7 @@
 import { InlineKeyboard } from "grammy";
 import type { CustomContext } from "../bot";
 import {
+  effectivePageCount,
   getNextKahfPage,
   getNextPage,
   getPageRange,
@@ -576,6 +577,7 @@ async function handleKahfResponse(
     weekSessions.reduce((sum, s) => sum + s.durationSeconds, 0) +
     (state.durationSeconds ?? 0);
   const isComplete = weekPagesRead >= KAHF_TOTAL_PAGES;
+  const sessionPages = effectivePageCount(pageStart, pageEnd, "kahf");
 
   if (isComplete) {
     const lastWeekResult = await getLastWeekKahfTotal(ctx.db, tz);
@@ -591,7 +593,7 @@ async function handleKahfResponse(
           isComplete: true,
           lastWeekTotalSeconds:
             lastWeekTotalSeconds > 0 ? lastWeekTotalSeconds : undefined,
-          sessionPages: count,
+          sessionPages,
         },
         t
       )
@@ -606,7 +608,7 @@ async function handleKahfResponse(
           weekPagesRead,
           weekTotalSeconds,
           isComplete: false,
-          sessionPages: count,
+          sessionPages,
         },
         t
       )

--- a/tests/data/pages.test.ts
+++ b/tests/data/pages.test.ts
@@ -72,17 +72,17 @@ describe("Al-Kahf constants", () => {
 
 describe("KAHF_FIRST_PAGE_WEIGHT", () => {
   it("is 0.4", () => {
-    expect(KAHF_FIRST_PAGE_WEIGHT).toBe(0.4);
+    expect(KAHF_FIRST_PAGE_WEIGHT).toBeCloseTo(4 / 15);
   });
 });
 
 describe("effectivePageCount", () => {
   it("adjusts kahf session starting at page 293", () => {
-    expect(effectivePageCount(293, 293, "kahf")).toBeCloseTo(0.4);
+    expect(effectivePageCount(293, 293, "kahf")).toBeCloseTo(4 / 15);
   });
 
   it("adjusts kahf multi-page session starting at 293", () => {
-    expect(effectivePageCount(293, 295, "kahf")).toBeCloseTo(2.4);
+    expect(effectivePageCount(293, 295, "kahf")).toBeCloseTo(2 + 4 / 15);
   });
 
   it("does not adjust kahf session not starting at 293", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -842,8 +842,8 @@ describe("Kahf partial page adjustment", () => {
     );
 
     const stats = unwrap(await getGlobalStats(db));
-    // 1 raw page -> 0.4 effective
-    expect(stats.totalPages).toBeCloseTo(0.4);
+    // 1 raw page -> 4/15 effective
+    expect(stats.totalPages).toBeCloseTo(4 / 15);
   });
 
   it("adjusts pages for kahf multi-page session in getPeriodStats", async () => {
@@ -863,8 +863,8 @@ describe("Kahf partial page adjustment", () => {
     );
 
     const stats = unwrap(await getPeriodStats(db, "week", "America/Cancun"));
-    // 3 raw pages -> 2.4 effective
-    expect(stats.pages).toBeCloseTo(2.4);
+    // 3 raw pages -> 2 + 4/15 effective
+    expect(stats.pages).toBeCloseTo(2 + 4 / 15);
   });
 
   it("does not adjust pages for normal session at page 293", async () => {

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -1101,10 +1101,10 @@ describe("formatHistoryLine with Kahf partial page", () => {
       },
       fr
     );
-    // 3 raw pages -> 2.4 effective (293 weighted 0.4)
-    // 2.4 pages / 1h = 2.4 p/h
+    // 3 raw pages -> 2 + 4/15 ≈ 2.267 effective (293 weighted 4/15)
+    // 2.267 pages / 1h ≈ 2.3 p/h
     expect(result).toBe(
-      "[K] #99 | 10/03 13h30 | 1h0m | Al-Kahf 18:1-110 (110v, 2.4p, 2.4p/h)"
+      "[K] #99 | 10/03 13h30 | 1h0m | Al-Kahf 18:1-110 (110v, 2.3p, 2.3p/h)"
     );
   });
 


### PR DESCRIPTION
## Description

Correct the Al-Kahf first page (293) weight from 6/15 (0.4) to 4/15 (~0.267), excluding the surah title and basmala lines that aren't actual verse content. Apply `effectivePageCount` in both `/kahf` handler and timer kahf handler confirmation messages, which were passing raw page count instead of weighted count, inflating the displayed reading speed.

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Follows existing code patterns
- [x] No secrets or credentials committed