### PR TITLE
Upgrade CI actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4  # reads packageManager from package.json
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5  # reads packageManager from package.json
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -23,9 +23,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4  # reads packageManager from package.json
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5  # reads packageManager from package.json
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` v4 -> v6
- Upgrade `actions/setup-node` v4 -> v6
- Upgrade `pnpm/action-setup` v4 -> v5

Fixes Node.js 20 deprecation warnings on GitHub Actions.