### PR TITLE
Add missing /graph and /edit commands to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ A Telegram bot for tracking Quran reading sessions with automatic prayer time re
 | `/stats` | Reading statistics |
 | `/progress` | Quran completion progress |
 | `/speed` | Reading speed analytics |
+| `/graph` | Speed evolution graph |
 | `/undo` | Undo the last session |
+| `/edit <id> <duration>` | Edit a session duration |
 | `/delete <id>` | Delete a session by ID |
 | `/config [key] [value]` | Configure city, country, timezone, language |
 | `/prayer` | Refresh prayer times |


### PR DESCRIPTION
## Description

Add `/graph` and `/edit` commands to the README commands table. Both commands exist in the codebase (handlers + locales) but were missing from documentation.

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Follows existing code patterns
- [x] No secrets or credentials committed