### PR TITLE
Fix Friday /go button starting normal timer instead of kahf

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -47,12 +47,14 @@ import {
   CALLBACK_PAGES_RE,
   CALLBACK_TIMER_CANCEL_RE,
   CALLBACK_TIMER_CONFIRM_RE,
+  CALLBACK_TIMER_GO_KAHF_RE,
   CALLBACK_TIMER_GO_RE,
   CALLBACK_TIMER_STOP_RE,
   cancelTimerStopCallback,
   confirmTimerStopCallback,
   goHandler,
   goTimerCallback,
+  goTimerKahfCallback,
   pagesCountCallback,
   pagesOtherCallback,
   stopHandler,
@@ -128,6 +130,7 @@ export function createBot(
 
   // Callbacks inline keyboard
   bot.callbackQuery(CALLBACK_TIMER_STOP_RE, stopTimerCallback);
+  bot.callbackQuery(CALLBACK_TIMER_GO_KAHF_RE, goTimerKahfCallback);
   bot.callbackQuery(CALLBACK_TIMER_GO_RE, goTimerCallback);
   bot.callbackQuery(CALLBACK_TIMER_CONFIRM_RE, confirmTimerStopCallback);
   bot.callbackQuery(CALLBACK_TIMER_CANCEL_RE, cancelTimerStopCallback);

--- a/src/handlers/timer.ts
+++ b/src/handlers/timer.ts
@@ -55,11 +55,13 @@ const CALLBACK_TIMER_CONFIRM = "timer_confirm_stop";
 const CALLBACK_TIMER_CANCEL = "timer_cancel_stop";
 const CALLBACK_TIMER_STOP = "timer_stop";
 export const CALLBACK_TIMER_GO = "timer_go";
+export const CALLBACK_TIMER_GO_KAHF = "timer_go_kahf";
 
 export const CALLBACK_TIMER_CONFIRM_RE = /^timer_confirm_stop$/;
 export const CALLBACK_TIMER_CANCEL_RE = /^timer_cancel_stop$/;
 export const CALLBACK_TIMER_STOP_RE = /^timer_stop$/;
 export const CALLBACK_TIMER_GO_RE = /^timer_go$/;
+export const CALLBACK_TIMER_GO_KAHF_RE = /^timer_go_kahf$/;
 export const CALLBACK_PAGES_RE = /^pages:(\d+)$/;
 const CALLBACK_PAGES_OTHER = "pages:other";
 export const CALLBACK_PAGES_OTHER_RE = /^pages:other$/;
@@ -403,6 +405,58 @@ async function executeTimerGoNormalPage(
 export async function goTimerCallback(ctx: CustomContext): Promise<void> {
   const t = ctx.locale;
   await executeTimerGoNormalPage(
+    ctx.db,
+    (...args) => ctx.editMessageText(...args),
+    t
+  );
+  await ctx.answerCallbackQuery();
+}
+
+// --- Shared go logic (kahf, no args) ---
+
+async function executeTimerGoKahf(
+  db: D1Database,
+  send: SendFn,
+  t: Locale
+): Promise<void> {
+  const [existing, tz] = await Promise.all([
+    getTimerState(db),
+    getTimezone(db),
+  ]);
+  if (existing) {
+    const elapsed = Math.floor((Date.now() - existing.startedEpoch) / 1000);
+    await send(
+      formatError(t.timer.alreadyActive(formatDuration(elapsed, t)), t)
+    );
+    return;
+  }
+
+  const weekSessions = await getKahfSessionsThisWeek(db, tz);
+  const pagesAlreadyRead = calculateKahfPagesRead(weekSessions);
+  if (pagesAlreadyRead >= KAHF_TOTAL_PAGES) {
+    await send(t.kahf.alreadyComplete);
+    return;
+  }
+
+  const now = getNowTimestamp(tz);
+  await setTimerState(db, {
+    startedAt: now,
+    startedEpoch: Date.now(),
+    type: "kahf",
+    args: "{}",
+    awaitingResponse: false,
+  });
+
+  await send(t.timer.startedKahf, {
+    reply_markup: new InlineKeyboard().text(t.timer.stop, CALLBACK_TIMER_STOP),
+  });
+}
+
+// --- Callback for inline Go button (Friday Kahf reminder) ---
+
+export async function goTimerKahfCallback(ctx: CustomContext): Promise<void> {
+  const t = ctx.locale;
+  await executeTimerGoKahf(
     ctx.db,
     (...args) => ctx.editMessageText(...args),
     t

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {
   WEEKLY_RECAP_HOUR,
 } from "./config";
 import { getNextKahfPage, getNextPage } from "./data/pages";
-import { CALLBACK_TIMER_GO } from "./handlers/timer";
+import { CALLBACK_TIMER_GO, CALLBACK_TIMER_GO_KAHF } from "./handlers/timer";
 import { getBotCommands, getLocale } from "./locales";
 import type { Locale } from "./locales/types";
 import { getConfig, setConfig } from "./services/db/config";
@@ -105,9 +105,10 @@ interface ScheduledContext {
   tz: string;
 }
 
-function buildGoKeyboard(t: Locale) {
+function buildGoKeyboard(t: Locale, kahf = false) {
+  const callbackData = kahf ? CALLBACK_TIMER_GO_KAHF : CALLBACK_TIMER_GO;
   return {
-    inline_keyboard: [[{ text: t.timer.go, callback_data: CALLBACK_TIMER_GO }]],
+    inline_keyboard: [[{ text: t.timer.go, callback_data: callbackData }]],
   };
 }
 
@@ -169,7 +170,7 @@ async function sendPrayerReminders(
     sctx.botToken,
     sctx.chatId,
     message,
-    buildGoKeyboard(sctx.t)
+    buildGoKeyboard(sctx.t, nextKahfPage !== undefined)
   );
   if (sent) {
     for (const prayer of duePrayers) {

--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -74,6 +74,7 @@ vi.mock("../src/services/weekly-recap", async (importOriginal) => {
   return { ...actual, buildWeeklyRecap: vi.fn() };
 });
 
+import { KAHF_TOTAL_PAGES } from "../src/data/pages";
 import { handleScheduled } from "../src/index";
 import { fr } from "../src/locales/fr";
 import { getConfig, setConfig } from "../src/services/db/config";
@@ -554,6 +555,126 @@ describe("handleScheduled", () => {
           nextKahfPage: 296,
         },
         fr
+      );
+    });
+
+    it("rappel de priere le vendredi utilise le bouton Go Kahf si Al-Kahf incomplet", async () => {
+      // 2026-03-13 is a Friday
+      vi.setSystemTime(new Date("2026-03-13T12:00:00Z"));
+
+      mockConfigValues({
+        chat_id: "123",
+        timezone: "America/Cancun",
+        city: "PDC",
+        country: "MX",
+        language: "fr",
+      });
+      vi.mocked(getTodayInTimezone).mockReturnValue("2026-03-13");
+      vi.mocked(getPrayerCache).mockResolvedValue({
+        date: "2026-03-13",
+        fajr: "05:30",
+        dhuhr: "12:00",
+        asr: "15:45",
+        maghrib: "18:30",
+        isha: "20:00",
+        fajr_sent: 0,
+        dhuhr_sent: 0,
+        asr_sent: 0,
+        maghrib_sent: 0,
+        isha_sent: 0,
+        streak_followup_sent: 0,
+        fetched_at: "2026-03-13",
+      });
+      vi.mocked(getNowInTimezone).mockReturnValue("12:12");
+      vi.mocked(getDueReminders).mockReturnValue(["dhuhr"]);
+      vi.mocked(getLastSession).mockResolvedValue(null);
+      vi.mocked(getKahfSessionsThisWeek).mockResolvedValue([]);
+      vi.mocked(calculateKahfPagesRead).mockReturnValue(0);
+      vi.mocked(getPeriodStats).mockResolvedValue({
+        ok: true,
+        value: { sessions: 0, ayahs: 0, seconds: 0, pages: 0, pageSeconds: 0 },
+      });
+      vi.mocked(calculateStreak).mockResolvedValue({
+        currentStreak: 0,
+        bestStreak: 0,
+      });
+      vi.mocked(formatReminder).mockReturnValue("Rappel vendredi");
+
+      await handleScheduled(db, "TOKEN");
+
+      expect(fetch).toHaveBeenCalledWith(
+        "https://api.telegram.org/botTOKEN/sendMessage",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            chat_id: "123",
+            text: "Rappel vendredi",
+            reply_markup: {
+              inline_keyboard: [
+                [{ text: "Go", callback_data: "timer_go_kahf" }],
+              ],
+            },
+          }),
+        })
+      );
+    });
+
+    it("rappel de priere le vendredi utilise le bouton Go normal si Al-Kahf termine", async () => {
+      // 2026-03-13 is a Friday
+      vi.setSystemTime(new Date("2026-03-13T12:00:00Z"));
+
+      mockConfigValues({
+        chat_id: "123",
+        timezone: "America/Cancun",
+        city: "PDC",
+        country: "MX",
+        language: "fr",
+      });
+      vi.mocked(getTodayInTimezone).mockReturnValue("2026-03-13");
+      vi.mocked(getPrayerCache).mockResolvedValue({
+        date: "2026-03-13",
+        fajr: "05:30",
+        dhuhr: "12:00",
+        asr: "15:45",
+        maghrib: "18:30",
+        isha: "20:00",
+        fajr_sent: 0,
+        dhuhr_sent: 0,
+        asr_sent: 0,
+        maghrib_sent: 0,
+        isha_sent: 0,
+        streak_followup_sent: 0,
+        fetched_at: "2026-03-13",
+      });
+      vi.mocked(getNowInTimezone).mockReturnValue("12:12");
+      vi.mocked(getDueReminders).mockReturnValue(["dhuhr"]);
+      vi.mocked(getLastSession).mockResolvedValue(null);
+      vi.mocked(getKahfSessionsThisWeek).mockResolvedValue([]);
+      vi.mocked(calculateKahfPagesRead).mockReturnValue(KAHF_TOTAL_PAGES);
+      vi.mocked(getPeriodStats).mockResolvedValue({
+        ok: true,
+        value: { sessions: 0, ayahs: 0, seconds: 0, pages: 0, pageSeconds: 0 },
+      });
+      vi.mocked(calculateStreak).mockResolvedValue({
+        currentStreak: 0,
+        bestStreak: 0,
+      });
+      vi.mocked(formatReminder).mockReturnValue("Rappel vendredi");
+
+      await handleScheduled(db, "TOKEN");
+
+      expect(fetch).toHaveBeenCalledWith(
+        "https://api.telegram.org/botTOKEN/sendMessage",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            chat_id: "123",
+            text: "Rappel vendredi",
+            reply_markup: {
+              inline_keyboard: [[{ text: "Go", callback_data: "timer_go" }]],
+            },
+          }),
+        })
       );
     });
   });

--- a/tests/handlers/timer.test.ts
+++ b/tests/handlers/timer.test.ts
@@ -1,11 +1,13 @@
 // tests/handlers/timer.test.ts
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CustomContext } from "../../src/bot";
+import { KAHF_PAGE_END, KAHF_PAGE_START } from "../../src/data/pages";
 import {
   cancelTimerStopCallback,
   confirmTimerStopCallback,
   goHandler,
   goTimerCallback,
+  goTimerKahfCallback,
   pagesCountCallback,
   pagesOtherCallback,
   stopHandler,
@@ -921,6 +923,69 @@ describe("goTimerCallback", () => {
     const msg = (ctx.editMessageText as ReturnType<typeof vi.fn>).mock
       .calls[0][0] as string;
     expect(msg).toContain("timer est déjà actif");
+    expect(ctx.answerCallbackQuery).toHaveBeenCalled();
+  });
+});
+
+describe("goTimerKahfCallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSetTimerState.mockResolvedValue(undefined);
+    vi.mocked(getTimezone).mockResolvedValue("America/Cancun");
+    vi.mocked(getNowTimestamp).mockReturnValue("2026-03-13 10:00:00");
+  });
+
+  it("demarre un timer kahf et affiche le clavier Stop", async () => {
+    mockGetTimerState.mockResolvedValue(null);
+    mockGetKahfSessionsThisWeek.mockResolvedValue([]);
+
+    const ctx = createCallbackContext("timer_go_kahf");
+    await goTimerKahfCallback(ctx);
+
+    expect(mockSetTimerState).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ type: "kahf", args: "{}" })
+    );
+    const opts = (ctx.editMessageText as ReturnType<typeof vi.fn>).mock
+      .calls[0][1];
+    expect(opts).toHaveProperty("reply_markup");
+    expect(ctx.answerCallbackQuery).toHaveBeenCalled();
+  });
+
+  it("timer deja actif -> erreur, pas de nouveau timer", async () => {
+    const epoch = Date.now() - 300_000;
+    mockGetTimerState.mockResolvedValue(
+      makeTimerState({ startedEpoch: epoch })
+    );
+
+    const ctx = createCallbackContext("timer_go_kahf");
+    await goTimerKahfCallback(ctx);
+
+    expect(mockSetTimerState).not.toHaveBeenCalled();
+    const msg = (ctx.editMessageText as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(msg).toContain("timer est déjà actif");
+    expect(ctx.answerCallbackQuery).toHaveBeenCalled();
+  });
+
+  it("Al-Kahf deja terminee cette semaine -> pas de timer", async () => {
+    mockGetTimerState.mockResolvedValue(null);
+    mockGetKahfSessionsThisWeek.mockResolvedValue([
+      {
+        id: 1,
+        type: "kahf",
+        pageStart: KAHF_PAGE_START,
+        pageEnd: KAHF_PAGE_END,
+      } as Session,
+    ]);
+
+    const ctx = createCallbackContext("timer_go_kahf");
+    await goTimerKahfCallback(ctx);
+
+    expect(mockSetTimerState).not.toHaveBeenCalled();
+    const msg = (ctx.editMessageText as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(msg).toContain("Al-Kahf");
     expect(ctx.answerCallbackQuery).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Friday prayer reminders already display the next Al-Kahf page, but the "Go" button was wired to `timer_go` → `normal_page` timer. Finishing the reading recorded the session as `normal` type instead of `kahf`.
- Add a dedicated `timer_go_kahf` callback (`goTimerKahfCallback` / `executeTimerGoKahf`) that starts a `kahf` timer with the same Al-Kahf completion guard as `/go kahf`.
- `buildGoKeyboard` in `src/index.ts` now selects the callback data based on `nextKahfPage !== undefined`. Streak follow-up keeps the normal `timer_go` button.

## Test plan

- [x] `pnpm test` — 658 passing (5 new tests)
- [x] `pnpm check` — biome clean
- [ ] Manual QA on Friday: click Go from a prayer reminder, finish the reading, verify session recorded as `kahf` type
- [ ] Manual QA on Friday with Al-Kahf already complete for the week: Go should start a normal timer
- [ ] Manual QA outside Friday: Go unchanged, starts a normal timer