### PR TITLE
Add continue-reading prompt after timer sessions

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -43,6 +43,7 @@ import {
   statsHandler,
 } from "./handlers/stats";
 import {
+  CALLBACK_CONTINUE_RE,
   CALLBACK_PAGES_OTHER_RE,
   CALLBACK_PAGES_RE,
   CALLBACK_TIMER_CANCEL_RE,
@@ -51,6 +52,7 @@ import {
   CALLBACK_TIMER_STOP_RE,
   cancelTimerStopCallback,
   confirmTimerStopCallback,
+  continueReadingCallback,
   goHandler,
   goTimerCallback,
   pagesCountCallback,
@@ -140,6 +142,7 @@ export function createBot(
   bot.callbackQuery(CALLBACK_READ_NODUR_CONFIRM_RE, confirmReadNoDurCallback);
   bot.callbackQuery(CALLBACK_EXTRA_NODUR_CONFIRM_RE, confirmExtraNoDurCallback);
   bot.callbackQuery(CALLBACK_KAHF_NODUR_CONFIRM_RE, confirmKahfNoDurCallback);
+  bot.callbackQuery(CALLBACK_CONTINUE_RE, continueReadingCallback);
   bot.callbackQuery(CALLBACK_NODUR_CANCEL_RE, async (ctx) => {
     await ctx.editMessageText(ctx.locale.session.cancelled);
     await ctx.answerCallbackQuery();

--- a/src/handlers/timer.ts
+++ b/src/handlers/timer.ts
@@ -551,6 +551,13 @@ export async function continueReadingCallback(
       await ctx.answerCallbackQuery();
       return;
     }
+  } else if (parsed.type === "extra_page") {
+    const pageResult = parsePage(String(parsed.page), t);
+    if (!pageResult.ok) {
+      await ctx.editMessageText(formatError(pageResult.error, t));
+      await ctx.answerCallbackQuery();
+      return;
+    }
   } else if (parsed.type === "normal_verse" || parsed.type === "extra_verse") {
     const valid = validateAyah(parsed.surah, parsed.ayah, t);
     if (!valid.ok) {

--- a/src/handlers/timer.ts
+++ b/src/handlers/timer.ts
@@ -11,6 +11,7 @@ import {
   KAHF_TOTAL_PAGES,
   TOTAL_PAGES,
 } from "../data/pages";
+import { getSurah } from "../data/surahs";
 import type { Locale } from "../locales/types";
 import { getNowTimestamp, getTimezone } from "../services/db/date-helpers";
 import {
@@ -63,6 +64,10 @@ export const CALLBACK_TIMER_GO_RE = /^timer_go$/;
 export const CALLBACK_PAGES_RE = /^pages:(\d+)$/;
 const CALLBACK_PAGES_OTHER = "pages:other";
 export const CALLBACK_PAGES_OTHER_RE = /^pages:other$/;
+export const CALLBACK_CONTINUE_RE =
+  /^cnt:(?:np|k|ep:\d+|nv:\d+:\d+|ev:\d+:\d+)$/;
+const CONTINUE_EXTRA_PAGE_RE = /^cnt:ep:(\d+)$/;
+const CONTINUE_VERSE_RE = /^cnt:(nv|ev):(\d+):(\d+)$/;
 
 // --- Parsed argument types ---
 
@@ -410,6 +415,174 @@ export async function goTimerCallback(ctx: CustomContext): Promise<void> {
   await ctx.answerCallbackQuery();
 }
 
+// --- Continue-reading prompt after timer sessions ---
+
+type ContinueOpts =
+  | { type: "normal_page"; pageEnd: number }
+  | { type: "extra_page"; pageEnd: number }
+  | { type: "normal_verse"; surahEnd: number; ayahEnd: number }
+  | { type: "extra_verse"; surahEnd: number; ayahEnd: number }
+  | { type: "kahf"; isComplete: boolean };
+
+function getNextVerse(
+  surahEnd: number,
+  ayahEnd: number
+): { surah: number; ayah: number } | null {
+  const surah = getSurah(surahEnd);
+  if (!surah) {
+    return null;
+  }
+  if (ayahEnd < surah.ayahCount) {
+    return { surah: surahEnd, ayah: ayahEnd + 1 };
+  }
+  if (surahEnd >= 114) {
+    return null;
+  }
+  return { surah: surahEnd + 1, ayah: 1 };
+}
+
+function buildContinueCallbackData(opts: ContinueOpts): string | null {
+  switch (opts.type) {
+    case "normal_page":
+      return opts.pageEnd >= TOTAL_PAGES ? null : "cnt:np";
+    case "extra_page":
+      return opts.pageEnd >= TOTAL_PAGES ? null : `cnt:ep:${opts.pageEnd + 1}`;
+    case "normal_verse": {
+      const next = getNextVerse(opts.surahEnd, opts.ayahEnd);
+      return next ? `cnt:nv:${next.surah}:${next.ayah}` : null;
+    }
+    case "extra_verse": {
+      const next = getNextVerse(opts.surahEnd, opts.ayahEnd);
+      return next ? `cnt:ev:${next.surah}:${next.ayah}` : null;
+    }
+    case "kahf":
+      return opts.isComplete ? null : "cnt:k";
+    default: {
+      const _exhaustive: never = opts;
+      return _exhaustive;
+    }
+  }
+}
+
+async function sendContinuePrompt(
+  ctx: CustomContext,
+  opts: ContinueOpts
+): Promise<void> {
+  const data = buildContinueCallbackData(opts);
+  if (!data) {
+    return;
+  }
+  const t = ctx.locale;
+  await ctx.reply(t.timer.continuePrompt, {
+    reply_markup: new InlineKeyboard().text(t.timer.go, data),
+  });
+}
+
+function parseContinueData(data: string): ParsedGoArgs | null {
+  if (data === "cnt:np") {
+    return { type: "normal_page" };
+  }
+  if (data === "cnt:k") {
+    return { type: "kahf" };
+  }
+  const extraPage = data.match(CONTINUE_EXTRA_PAGE_RE);
+  if (extraPage) {
+    return { type: "extra_page", page: Number(extraPage[1]) };
+  }
+  const verseMatch = data.match(CONTINUE_VERSE_RE);
+  if (verseMatch) {
+    const type = verseMatch[1] === "nv" ? "normal_verse" : "extra_verse";
+    return {
+      type,
+      surah: Number(verseMatch[2]),
+      ayah: Number(verseMatch[3]),
+    };
+  }
+  return null;
+}
+
+function continueStartedMessage(parsed: ParsedGoArgs, t: Locale): string {
+  switch (parsed.type) {
+    case "normal_page":
+      return t.timer.startedNormalPage;
+    case "extra_page":
+      return t.timer.startedExtraPage(String(parsed.page));
+    case "normal_verse":
+      return t.timer.startedNormalVerse(`${parsed.surah}:${parsed.ayah}`);
+    case "extra_verse":
+      return t.timer.startedExtraVerse(`${parsed.surah}:${parsed.ayah}`);
+    case "kahf":
+      return t.timer.startedKahf;
+    default: {
+      const _exhaustive: never = parsed;
+      return _exhaustive;
+    }
+  }
+}
+
+export async function continueReadingCallback(
+  ctx: CustomContext
+): Promise<void> {
+  const t = ctx.locale;
+  const data = ctx.callbackQuery?.data ?? "";
+
+  const parsed = parseContinueData(data);
+  if (!parsed) {
+    await ctx.answerCallbackQuery();
+    return;
+  }
+
+  const existing = await getTimerState(ctx.db);
+  if (existing) {
+    const elapsed = Math.floor((Date.now() - existing.startedEpoch) / 1000);
+    await ctx.editMessageText(
+      formatError(t.timer.alreadyActive(formatDuration(elapsed, t)), t)
+    );
+    await ctx.answerCallbackQuery();
+    return;
+  }
+
+  const tz = await getTimezone(ctx.db);
+
+  if (parsed.type === "normal_page") {
+    const lastSession = await getLastSession(ctx.db, "normal");
+    if (lastSession?.pageEnd === TOTAL_PAGES) {
+      await ctx.editMessageText(t.timer.quranFinished);
+      await ctx.answerCallbackQuery();
+      return;
+    }
+  } else if (parsed.type === "normal_verse" || parsed.type === "extra_verse") {
+    const valid = validateAyah(parsed.surah, parsed.ayah, t);
+    if (!valid.ok) {
+      await ctx.editMessageText(formatError(valid.error, t));
+      await ctx.answerCallbackQuery();
+      return;
+    }
+  } else if (parsed.type === "kahf") {
+    const weekSessions = await getKahfSessionsThisWeek(ctx.db, tz);
+    const pagesAlreadyRead = calculateKahfPagesRead(weekSessions);
+    if (pagesAlreadyRead >= KAHF_TOTAL_PAGES) {
+      await ctx.editMessageText(t.kahf.alreadyComplete);
+      await ctx.answerCallbackQuery();
+      return;
+    }
+  }
+
+  const now = getNowTimestamp(tz);
+  await setTimerState(ctx.db, {
+    startedAt: now,
+    startedEpoch: Date.now(),
+    type: parsed.type,
+    args: argsToJson(parsed),
+    awaitingResponse: false,
+  });
+
+  await ctx.editMessageText(continueStartedMessage(parsed, t), {
+    reply_markup: new InlineKeyboard().text(t.timer.stop, CALLBACK_TIMER_STOP),
+  });
+  await ctx.answerCallbackQuery();
+}
+
 // --- Shared response helpers ---
 
 function parsePageCount(text: string): number | null {
@@ -487,6 +660,13 @@ async function handlePageResponse(
   } else {
     await Promise.all([clearTimerState(ctx.db), ctx.reply(replyBase)]);
   }
+
+  if (sessionType === "normal" || sessionType === "extra") {
+    await sendContinuePrompt(ctx, {
+      type: sessionType === "normal" ? "normal_page" : "extra_page",
+      pageEnd,
+    });
+  }
 }
 
 async function handleVerseResponse(
@@ -563,6 +743,14 @@ async function handleVerseResponse(
     await ctx.reply(insertAfterFirstLine(replyBase, comparison));
   } else {
     await Promise.all([clearTimerState(ctx.db), ctx.reply(replyBase)]);
+  }
+
+  if (sessionType === "normal" || sessionType === "extra") {
+    await sendContinuePrompt(ctx, {
+      type: sessionType === "normal" ? "normal_verse" : "extra_verse",
+      surahEnd,
+      ayahEnd,
+    });
   }
 }
 
@@ -678,6 +866,8 @@ async function handleKahfResponse(
       )
     );
   }
+
+  await sendContinuePrompt(ctx, { type: "kahf", isComplete });
 }
 
 // --- Shared page dispatch ---

--- a/src/locales/ar.ts
+++ b/src/locales/ar.ts
@@ -331,6 +331,7 @@ export const ar: Locale = {
     overflowPages: (start, end, max) =>
       `تجاوز: الصفحات ${start}-${end} (الحد الأقصى ${max})`,
     internalError: "خطأ داخلي أثناء معالجة الاستجابة",
+    continuePrompt: "هل تريد المتابعة؟",
   },
 
   edit: {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -334,6 +334,7 @@ export const en: Locale = {
     overflowPages: (start, end, max) =>
       `overflow: pages ${start}-${end} (max ${max})`,
     internalError: "internal error while processing response",
+    continuePrompt: "Continue reading?",
   },
 
   edit: {

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -336,6 +336,7 @@ export const fr: Locale = {
     overflowPages: (start, end, max) =>
       `dépassement: pages ${start}-${end} (max ${max})`,
     internalError: "erreur interne lors du traitement de la réponse",
+    continuePrompt: "Continuer la lecture ?",
   },
 
   edit: {

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -397,6 +397,7 @@ export interface Locale {
     invalidGoExtraFormat: string;
     overflowPages: (start: number, end: number, max: number) => string;
     internalError: string;
+    continuePrompt: string;
   };
 
   // Validation (quran.ts)

--- a/tests/handlers/timer.test.ts
+++ b/tests/handlers/timer.test.ts
@@ -4,6 +4,7 @@ import type { CustomContext } from "../../src/bot";
 import {
   cancelTimerStopCallback,
   confirmTimerStopCallback,
+  continueReadingCallback,
   goHandler,
   goTimerCallback,
   pagesCountCallback,
@@ -1180,6 +1181,332 @@ describe("pagesOtherCallback", () => {
     await pagesOtherCallback(ctx);
 
     expect(ctx.editMessageText).toHaveBeenCalledWith("Timer introuvable.");
+    expect(ctx.answerCallbackQuery).toHaveBeenCalled();
+  });
+});
+
+describe("sendContinuePrompt (via timerResponseHandler)", () => {
+  const next = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getTimezone).mockResolvedValue("America/Cancun");
+    vi.mocked(getNowTimestamp).mockReturnValue("2026-03-15 14:00:00");
+    vi.mocked(get7DayTypeAvgSpeed).mockResolvedValue({
+      pagesPerHour: 10,
+      versesPerHour: 100,
+    });
+    mockGetLastSession.mockResolvedValue(null);
+    mockGetKahfSessionsThisWeek.mockResolvedValue([]);
+    mockGetLastWeekKahfTotal.mockResolvedValue({ ok: true, value: 0 });
+  });
+
+  it("normal_page -> envoie un second reply 'Continuer la lecture ?' avec cnt:np", async () => {
+    mockGetTimerState.mockResolvedValue(
+      makeTimerState({
+        awaitingResponse: true,
+        durationSeconds: 300,
+        type: "normal_page",
+        args: "{}",
+      })
+    );
+    mockInsertSession.mockResolvedValue({
+      ok: true,
+      value: makeSession({ pageStart: 1, pageEnd: 3 }),
+    });
+
+    const ctx = createMessageContext("3");
+    await timerResponseHandler(ctx, next);
+
+    const calls = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.length).toBe(2);
+    expect(calls[1][0]).toBe("Continuer la lecture ?");
+    const markup = calls[1][1]?.reply_markup;
+    expect(JSON.stringify(markup)).toContain("cnt:np");
+    expect(JSON.stringify(markup)).toContain("Go");
+  });
+
+  it("normal_page pageEnd === TOTAL_PAGES -> pas de prompt", async () => {
+    mockGetTimerState.mockResolvedValue(
+      makeTimerState({
+        awaitingResponse: true,
+        durationSeconds: 300,
+        type: "normal_page",
+        args: "{}",
+      })
+    );
+    mockGetLastSession.mockResolvedValue(makeSession({ pageEnd: 603 }));
+    mockInsertSession.mockResolvedValue({
+      ok: true,
+      value: makeSession({ pageStart: 604, pageEnd: 604 }),
+    });
+
+    const ctx = createMessageContext("1");
+    await timerResponseHandler(ctx, next);
+
+    const calls = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.length).toBe(1);
+  });
+
+  it("extra_page -> envoie prompt avec cnt:ep:<pageEnd+1>", async () => {
+    mockGetTimerState.mockResolvedValue(
+      makeTimerState({
+        awaitingResponse: true,
+        durationSeconds: 300,
+        type: "extra_page",
+        args: JSON.stringify({ page: 300 }),
+      })
+    );
+    mockInsertSession.mockResolvedValue({
+      ok: true,
+      value: makeSession({ pageStart: 300, pageEnd: 301, type: "extra" }),
+    });
+
+    const ctx = createMessageContext("2");
+    await timerResponseHandler(ctx, next);
+
+    const calls = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.length).toBe(2);
+    expect(JSON.stringify(calls[1][1]?.reply_markup)).toContain("cnt:ep:302");
+  });
+
+  it("normal_verse -> envoie prompt avec cnt:nv:<surah>:<ayah+1>", async () => {
+    mockGetTimerState.mockResolvedValue(
+      makeTimerState({
+        awaitingResponse: true,
+        durationSeconds: 600,
+        type: "normal_verse",
+        args: JSON.stringify({ surah: 2, ayah: 77 }),
+      })
+    );
+    mockInsertSession.mockResolvedValue({
+      ok: true,
+      value: makeSession({
+        surahStart: 2,
+        ayahStart: 77,
+        surahEnd: 2,
+        ayahEnd: 83,
+      }),
+    });
+
+    const ctx = createMessageContext("2:83");
+    await timerResponseHandler(ctx, next);
+
+    const calls = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.length).toBe(2);
+    expect(JSON.stringify(calls[1][1]?.reply_markup)).toContain("cnt:nv:2:84");
+  });
+
+  it("verse a la fin d'une sourate -> prompt pointe vers la sourate suivante", async () => {
+    mockGetTimerState.mockResolvedValue(
+      makeTimerState({
+        awaitingResponse: true,
+        durationSeconds: 600,
+        type: "normal_verse",
+        args: JSON.stringify({ surah: 1, ayah: 1 }),
+      })
+    );
+    mockInsertSession.mockResolvedValue({
+      ok: true,
+      value: makeSession({
+        surahStart: 1,
+        ayahStart: 1,
+        surahEnd: 1,
+        ayahEnd: 7,
+      }),
+    });
+
+    const ctx = createMessageContext("1:7");
+    await timerResponseHandler(ctx, next);
+
+    const calls = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls;
+    expect(JSON.stringify(calls[1][1]?.reply_markup)).toContain("cnt:nv:2:1");
+  });
+
+  it("kahf complete -> pas de prompt", async () => {
+    mockGetTimerState.mockResolvedValue(
+      makeTimerState({
+        awaitingResponse: true,
+        durationSeconds: 600,
+        type: "kahf",
+        args: "{}",
+      })
+    );
+    mockGetKahfSessionsThisWeek.mockResolvedValue([]);
+    mockInsertSession.mockResolvedValue({
+      ok: true,
+      value: makeSession({ pageStart: 293, pageEnd: 304, type: "kahf" }),
+    });
+
+    const ctx = createMessageContext("12");
+    await timerResponseHandler(ctx, next);
+
+    const calls = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.length).toBe(1);
+  });
+
+  it("kahf non complete -> envoie prompt avec cnt:k", async () => {
+    mockGetTimerState.mockResolvedValue(
+      makeTimerState({
+        awaitingResponse: true,
+        durationSeconds: 600,
+        type: "kahf",
+        args: "{}",
+      })
+    );
+    mockGetKahfSessionsThisWeek.mockResolvedValue([]);
+    mockInsertSession.mockResolvedValue({
+      ok: true,
+      value: makeSession({ pageStart: 293, pageEnd: 295, type: "kahf" }),
+    });
+
+    const ctx = createMessageContext("3");
+    await timerResponseHandler(ctx, next);
+
+    const calls = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.length).toBe(2);
+    expect(JSON.stringify(calls[1][1]?.reply_markup)).toContain("cnt:k");
+  });
+});
+
+describe("continueReadingCallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetTimerState.mockResolvedValue(null);
+    mockSetTimerState.mockResolvedValue(undefined);
+    vi.mocked(getTimezone).mockResolvedValue("America/Cancun");
+    vi.mocked(getNowTimestamp).mockReturnValue("2026-03-15 14:00:00");
+    mockGetLastSession.mockResolvedValue(null);
+    mockGetKahfSessionsThisWeek.mockResolvedValue([]);
+  });
+
+  it("cnt:np -> cree un timer normal_page et affiche bouton Stop", async () => {
+    const ctx = createCallbackContext("cnt:np");
+    await continueReadingCallback(ctx);
+
+    expect(mockSetTimerState).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ type: "normal_page", args: "{}" })
+    );
+    const msg = (ctx.editMessageText as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(msg).toContain("Timer démarré");
+    expect(ctx.answerCallbackQuery).toHaveBeenCalled();
+  });
+
+  it("cnt:k -> cree un timer kahf", async () => {
+    const ctx = createCallbackContext("cnt:k");
+    await continueReadingCallback(ctx);
+
+    expect(mockSetTimerState).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ type: "kahf", args: "{}" })
+    );
+  });
+
+  it("cnt:ep:302 -> cree un timer extra_page a la page 302", async () => {
+    const ctx = createCallbackContext("cnt:ep:302");
+    await continueReadingCallback(ctx);
+
+    expect(mockSetTimerState).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        type: "extra_page",
+        args: JSON.stringify({ page: 302 }),
+      })
+    );
+  });
+
+  it("cnt:nv:2:84 -> cree un timer normal_verse", async () => {
+    const ctx = createCallbackContext("cnt:nv:2:84");
+    await continueReadingCallback(ctx);
+
+    expect(mockSetTimerState).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        type: "normal_verse",
+        args: JSON.stringify({ surah: 2, ayah: 84 }),
+      })
+    );
+  });
+
+  it("cnt:ev:2:84 -> cree un timer extra_verse", async () => {
+    const ctx = createCallbackContext("cnt:ev:2:84");
+    await continueReadingCallback(ctx);
+
+    expect(mockSetTimerState).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        type: "extra_verse",
+        args: JSON.stringify({ surah: 2, ayah: 84 }),
+      })
+    );
+  });
+
+  it("avec timer deja actif -> erreur, ne cree pas de timer", async () => {
+    mockGetTimerState.mockResolvedValue(makeTimerState());
+
+    const ctx = createCallbackContext("cnt:np");
+    await continueReadingCallback(ctx);
+
+    const msg = (ctx.editMessageText as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(msg).toContain("timer est déjà actif");
+    expect(mockSetTimerState).not.toHaveBeenCalled();
+  });
+
+  it("cnt:np quand Coran termine -> erreur", async () => {
+    mockGetLastSession.mockResolvedValue(makeSession({ pageEnd: 604 }));
+
+    const ctx = createCallbackContext("cnt:np");
+    await continueReadingCallback(ctx);
+
+    const msg = (ctx.editMessageText as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(msg).toContain("terminé le Coran");
+    expect(mockSetTimerState).not.toHaveBeenCalled();
+  });
+
+  it("cnt:k quand kahf complet -> erreur", async () => {
+    mockGetKahfSessionsThisWeek.mockResolvedValue([
+      makeSession({ pageStart: 293, pageEnd: 304, type: "kahf" }),
+    ]);
+
+    const ctx = createCallbackContext("cnt:k");
+    await continueReadingCallback(ctx);
+
+    const msg = (ctx.editMessageText as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(msg).toContain("Al-Kahf déjà terminée");
+    expect(mockSetTimerState).not.toHaveBeenCalled();
+  });
+
+  it("cnt:nv avec verset invalide -> erreur", async () => {
+    const ctx = createCallbackContext("cnt:nv:1:999");
+    await continueReadingCallback(ctx);
+
+    const msg = (ctx.editMessageText as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(msg).toContain("Erreur");
+    expect(mockSetTimerState).not.toHaveBeenCalled();
+  });
+
+  it("cnt:ep:9999 -> erreur page invalide, pas de timer", async () => {
+    const ctx = createCallbackContext("cnt:ep:9999");
+    await continueReadingCallback(ctx);
+
+    const msg = (ctx.editMessageText as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(msg).toContain("Erreur");
+    expect(mockSetTimerState).not.toHaveBeenCalled();
+  });
+
+  it("callback data invalide -> ne fait que answerCallbackQuery", async () => {
+    const ctx = createCallbackContext("cnt:zz");
+    await continueReadingCallback(ctx);
+
+    expect(mockSetTimerState).not.toHaveBeenCalled();
+    expect(ctx.editMessageText).not.toHaveBeenCalled();
     expect(ctx.answerCallbackQuery).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- After a timer-driven session ends (via `/stop`), sends a follow-up "Continuer la lecture ?" message with an inline `Go` button
- Clicking `Go` restarts a timer of the **same type** at the **next position** (auto-derived):
  - `normal_page` / `extra_page` → next page after the just-recorded one
  - `normal_verse` / `extra_verse` → verse right after `ayahEnd` (rolls over to next surah when needed)
  - `kahf` → next Al-Kahf page for the week
- Prompt is skipped when there is nothing to continue: Quran finished (page 604), weekly Al-Kahf complete, last verse of the Quran reached
- Callback handler re-validates state (e.g. rechecks Quran/kahf completion, ayah validity) and refuses if a timer is already active

## Implementation

- New locale key `timer.continuePrompt` (en/fr/ar). Button reuses existing `timer.go`
- New `CALLBACK_CONTINUE_RE = /^cnt:(?:np|k|ep:\d+|nv:\d+:\d+|ev:\d+:\d+)$/` and `continueReadingCallback` in `src/handlers/timer.ts`
- Not triggered from manual `/read`, `/session`, `/extra`, `/kahf` commands — only from timer flow completions in `handlePageResponse`, `handleVerseResponse`, `handleKahfResponse`
- Reuses existing `argsToJson` and `ParsedGoArgs` type for timer-state creation

## Test plan

- [ ] `/go` → wait → `/stop` → answer pages → receive session confirmation + "Continuer la lecture ?" message
- [ ] Click `Go` → original message edits to "Timer démarré…" + Stop button; new timer is active
- [ ] `/go 2:77` → `/stop` → answer `2:100` → prompt suggests Go; clicking starts verse timer from 2:101
- [ ] `/go extra 300` → `/stop` → answer 2 pages → prompt; clicking starts extra timer from page 302
- [ ] `/go kahf` → `/stop` → complete the last kahf page of the week → no prompt (isComplete)
- [ ] Finish page 604 via timer → no prompt
- [ ] Manual `/read 3` does NOT send the prompt
- [ ] Click `Go` while another timer is already active → message shows "timer already active" error