### PR TITLE
Apply D1 migrations automatically in CI deploy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,21 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Configure wrangler.toml
+        run: |
+          sed -i 's/<YOUR_D1_DATABASE_ID>/${{ secrets.D1_DATABASE_ID }}/' wrangler.toml
+          sed -i 's/<OAUTH_KV_NAMESPACE_ID>/${{ secrets.OAUTH_KV_NAMESPACE_ID }}/' wrangler.toml
+      - name: Apply D1 migrations
+        run: npx wrangler d1 migrations apply quran-tracker --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          NO_COLOR: "1"
       - name: Deploy
         id: deploy
         # Requires BOT_TOKEN, ALLOWED_USER_ID, and MCP_SESSION_HMAC_SECRET to be set
         # as Cloudflare secrets (via wrangler secret put) before first deploy
         run: |
-          sed -i 's/<YOUR_D1_DATABASE_ID>/${{ secrets.D1_DATABASE_ID }}/' wrangler.toml
-          sed -i 's/<OAUTH_KV_NAMESPACE_ID>/${{ secrets.OAUTH_KV_NAMESPACE_ID }}/' wrangler.toml
           DEPLOY_OUTPUT=$(npx wrangler deploy 2>&1)
           echo "$DEPLOY_OUTPUT"
           # Strip ANSI escape codes (wrangler v4 emits colors even in CI)

--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ wrangler d1 create quran-tracker
 wrangler d1 execute quran-tracker --remote --file=schema.sql
 ```
 
+Subsequent schema changes are tracked in `migrations/`. The CI workflow applies them automatically before each deploy. To apply them manually (e.g. before first deploy or when running locally):
+
+```bash
+wrangler d1 migrations apply quran-tracker --remote   # production
+wrangler d1 migrations apply quran-tracker --local    # local dev DB
+```
+
 ### 2. Provision the OAuth KV namespace (for the MCP server)
 
 ```bash


### PR DESCRIPTION
## Summary
- The `deploy` job now runs `wrangler d1 migrations apply quran-tracker --remote` before `wrangler deploy`, so any pending migration in `migrations/` reaches the remote D1.
- Extracted the `wrangler.toml` `sed` substitutions into their own step so the migrate step can read the configured `database_id`.
- Documented the migration step in `README.md`.

Fixes #83 — `/read` saves without a timer were failing with `NOT NULL constraint failed: sessions.duration_seconds` because `0006_allow-null-duration.sql` (added in #79) had never been applied to the remote D1. Once this PR merges, the deploy job will apply it automatically.

## Test plan
- [x] `pnpm test` (733/733)
- [x] YAML syntax validated
- [ ] After merge: confirm `Apply D1 migrations` step succeeds in the CI run
- [ ] After merge: try `/read 1` (no duration) in Telegram and verify the session is recorded